### PR TITLE
Export file shortcut

### DIFF
--- a/frontend/src/lib/components/EnhancedDatasetView.svelte
+++ b/frontend/src/lib/components/EnhancedDatasetView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import DataframeView from './DataframeView.svelte';
     import { onMount } from 'svelte';
-    import { getApiUrl, fetchApi } from "$lib/utils/api";
+    import {fetchApi } from "$lib/utils/api";
 
     export let datasetPath: string;
     export let datasetName: string;

--- a/frontend/src/lib/templates/codeTemplates.ts
+++ b/frontend/src/lib/templates/codeTemplates.ts
@@ -2,6 +2,7 @@ export const codeTemplates = {
     polars: `# https://docs.pola.rs/api/python/stable/reference/
 
 import polars as pl
+#from functions.mako import save
 
 data = {"a": [1, 2], "b": [3, 4]}
 df = pl.DataFrame(data)


### PR DESCRIPTION
I added shortcut that will let you save the python or SQL file you are making locally on your computer using the native save interface of the users computer. This way you can take the python you are working on somewhere else.

<img width="2410" alt="Screenshot 2025-04-05 at 7 48 23 pm" src="https://github.com/user-attachments/assets/e1d380cb-93a3-46c4-9015-f13ea808e79d" />
